### PR TITLE
Fix missing `e.message` attr in exception handlers

### DIFF
--- a/kitsu.py
+++ b/kitsu.py
@@ -78,7 +78,7 @@ def fetch_anime(query):
     try:
         anime.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        return "HTTP error: " + e.message
+        return "HTTP error: " + str(e)
 
     try:
         Data = anime.json()
@@ -193,7 +193,7 @@ def fetch_manga(query):
     try:
         manga.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        return "HTTP error: " + e.message
+        return "HTTP error: " + str(e)
 
     try:
         Data = manga.json()
@@ -285,7 +285,7 @@ def fetch_user(query):
     try:
         user.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        return "HTTP error: " + e.message
+        return "HTTP error: " + str(e)
 
     try:
         uData = user.json()
@@ -371,7 +371,7 @@ def fetch_character(query):
     try:
         character.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        return "HTTP error: " + e.message
+        return "HTTP error: " + str(e)
 
     try:
         Data = character.json()


### PR DESCRIPTION
There is no `message` attribute in `requests.exceptions.HTTPError`. Just cast the exception to a string and let its `__str__()` method handle it. Closes #1.